### PR TITLE
修复了一处JVM冲突，更改了一些不规范语法

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+/.idea

--- a/app/src/main/java/com/github/miwu/miot/widget/HumidifierBar.kt
+++ b/app/src/main/java/com/github/miwu/miot/widget/HumidifierBar.kt
@@ -19,7 +19,7 @@ class HumidifierBar(context: Context) : MiotBaseWidget<Binding>(context) {
     private var level = 1
         set(value) {
             field = value
-            setLevel(value)
+            setLevelDebug(value)
         }
     private val levelList = getProperty("fan-level").valueList!!
 
@@ -38,12 +38,12 @@ class HumidifierBar(context: Context) : MiotBaseWidget<Binding>(context) {
                 index++
             }
             val obj = getPropertyWithSiid("fan-level")
-            level = levelList[index].value
+            this.level = levelList[index].value
             putValue(level, obj.first, obj.second.iid)
         }
     }
 
-    private fun setLevel(value: Int) {
+    private fun setLevelDebug(value: Int) {
         binding.modeText.text = levelList.first { it.value == value }.description
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -54,7 +54,7 @@
     <string name="EmptyFood">已经没得吃了</string>
     <string name="Medium">中速</string>
     <string name="High">高速</string>
-    <string name="home_desc">%s个房间/%s个设备</string>
+    <string name="home_desc">%1$s个房间/%2$s个设备</string>
     <string name="home_desc_share">共享家庭</string>
     <string name="about">关于</string>
     <string name="license_content">一. 本开源项目仅供个人学习交流使用, 方便 Android 手表端可以控制米家的智能家居.\n二. 本项目完全免费, 可能存在较多漏洞, 维护者仅保证自己能正常使用, 存在问题请通过项目页 Issues 反馈.\n三. 本项目中所有适配的接口均来自小米公司 (北京小米科技有限责任公司) 旗下米家 (MIJIA), 本项目不对其控制的安全性负责.\n四. 本项目会将账户、密码、家庭等信息, 缓存在安装设备本地, 不含任何上传个人信息的接口.\n五. 真诚希望小米官方能够推出 `米家 For Android Watch`, 使广大消费者能用上.\n六. 本项目仅供个人学习交流使用, 切勿进行传播、任何形式的盈利, 未涉及的问题请参见国家有关法律法规, 以国家法律法规为准.\n\n项目仓库地址:\nhttps://github.com/sky130/MiWu</string>
@@ -69,7 +69,7 @@
     <string name="start_clean">开始清洁</string>
     <string name="check_crash">可至仓库 Issues 页寻求帮助\n下面是最新的一份闪退日志</string>
     <string name="crash_path">日志保存路径:</string>
-    <string name="feed_num">%s份 (约 %sg)</string>
+    <string name="feed_num">%1$s份 (约 %2$sg)</string>
     <string name="auto_feed_plan">自动喂食计划</string>
     <string name="Normal">正常</string>
     <string name="miwu_tips">请在设备页中收藏设备</string>


### PR DESCRIPTION
重命名了app/src/main/java/com/github/miwu/miot/widget/HumidifierBar.kt里面的setLevel函数为setLevelDebug，这能修复这样的错误：
app/src/main/java/com/github/miwu/miot/widget/HumidifierBar.kt:20:9 Platform declaration clash: The following declarations have the same JVM signature (setLevel(I)V):
    fun `<set-level>`(value: Int): Unit defined in com.github.miwu.miot.widget.HumidifierBar
    fun setLevel(value: Int): Unit defined in com.github.miwu.miot.widget.HumidifierBar
虽然我并不知道原因，但是这样修完能build了）
建议核查是否是setLevel与其他文件里面的JVM 签名冲突了

额外的，更改了一个不规范语法，尽管并不影响使用，但是build的时候会弹出错误，基于强迫症修了
目前加湿器只能看见温湿度数据，不能显示按钮