### PR TITLE
Feat: 引入 `@Mock` 注解支持并重构 KSP 处理器结构

### DIFF
--- a/miwu-support-annotation/src/commonMain/kotlin/miwu/annotation/Mock.kt
+++ b/miwu-support-annotation/src/commonMain/kotlin/miwu/annotation/Mock.kt
@@ -1,0 +1,8 @@
+package miwu.annotation
+
+import miwu.annotation.basic.MockClient
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class Mock(val mockClient: KClass<out MockClient>)

--- a/miwu-support-annotation/src/commonMain/kotlin/miwu/annotation/basic/MockClient.kt
+++ b/miwu-support-annotation/src/commonMain/kotlin/miwu/annotation/basic/MockClient.kt
@@ -1,0 +1,3 @@
+package miwu.annotation.basic
+
+interface MockClient

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/MiwuProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/MiwuProcessor.kt
@@ -1,0 +1,19 @@
+package miwu.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.processing.SymbolProcessor as Processor
+
+abstract class MiwuProcessor : Processor {
+    private var isProcessingOver = false
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (isProcessingOver) return emptyList()
+        isProcessingOver = true
+        val processedSymbols = onProcess(resolver)
+        return processedSymbols
+    }
+
+    abstract fun onProcess(resolver: Resolver): List<KSAnnotated>
+
+}

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/device/DeviceProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/device/DeviceProcessor.kt
@@ -11,22 +11,20 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import miwu.annotation.Device
+import miwu.processor.MiwuProcessor
 
 internal class DeviceProcessor(
     private val options: Map<String, String>,
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
-) : Processor {
+) : MiwuProcessor() {
 
-    private var isProcessingOver = false
 
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (isProcessingOver) return emptyList()
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
         val deviceMap = collectDeviceClasses(resolver)
         if (deviceMap.isNotEmpty()) {
             generateDeviceRegistry(deviceMap)
         }
-        isProcessingOver = true
         return emptyList()
     }
 
@@ -100,6 +98,6 @@ internal class DeviceProcessor(
 
     companion object {
         private const val OBJECT_NAME = "DeviceRegistry"
-        private const val PACKAGE_NAME = "miwu.widget.generated.device"
+        private const val PACKAGE_NAME = "miwu.support.generated.device"
     }
 }

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/icon/IconsProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/icon/IconsProcessor.kt
@@ -4,6 +4,7 @@ import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ksp.writeTo
+import miwu.processor.MiwuProcessor
 import java.io.File
 import java.io.InputStream
 
@@ -11,18 +12,14 @@ class IconsProcessor(
     private val options: Map<String, String>,
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger
-) : SymbolProcessor {
+) : MiwuProcessor() {
 
-    private var isProcessingOver = false
-
-    override fun process(resolver: Resolver): List<KSAnnotated> {
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
         if (options["miwu.icon.enabled"] == "false") return emptyList()
         val filePath = options["miwu.icon.filePath"] ?: return emptyList()
-        if (isProcessingOver) return emptyList()
         val iconNames = loadIconNames(filePath) ?: return emptyList()
         val processedIcons = processIconNames(iconNames)
         generateIconsInterface(processedIcons)
-        isProcessingOver = true
         return emptyList()
     }
 

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockProcessor.kt
@@ -1,0 +1,213 @@
+package miwu.processor.mock
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.asTypeName
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import kotlinx.coroutines.CoroutineScope
+import miwu.annotation.Mock
+import miwu.miot.model.att.SpecAtt
+import miwu.miot.model.miot.MiotDevice
+import miwu.processor.MiwuProcessor
+import kotlin.reflect.KClass
+
+internal class MockProcessor(
+    private val options: Map<String, String>,
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger
+) : MiwuProcessor() {
+
+
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
+        try {
+            val mockMappings = collectMockMappings(resolver)
+            generateMockRegistry(mockMappings)
+        } catch (e: Exception) {
+            logger.error("Failed to process mock annotations")
+        }
+        return emptyList()
+    }
+
+    private fun collectMockMappings(resolver: Resolver): Map<ClassName, ClassName> {
+        val mockMappings = mutableMapOf<ClassName, ClassName>()
+
+        resolver.getSymbolsWithAnnotation(Mock::class.qualifiedName!!)
+            .filterIsInstance<KSClassDeclaration>()
+            .forEach { declaration ->
+                try {
+                    processMockDeclaration(declaration, mockMappings)
+                } catch (e: Exception) {
+                    logger.error(
+                        "Failed to process mock declaration: ${declaration.qualifiedName?.asString()}",
+                        declaration
+                    )
+                }
+            }
+
+        return mockMappings
+    }
+
+    private fun processMockDeclaration(
+        declaration: KSClassDeclaration,
+        mockMappings: MutableMap<ClassName, ClassName>
+    ) {
+        val mockClassName = declaration.toClassName()
+        val wrappedClassName = extractWrappedClassName(declaration)
+
+        if (wrappedClassName != null) {
+            mockMappings[mockClassName] = wrappedClassName
+            logger.info("Registered mock: $mockClassName -> $wrappedClassName")
+        } else {
+            logger.error(
+                "Failed to extract wrapped class from @Mock annotation",
+                declaration
+            )
+        }
+    }
+
+    private fun extractWrappedClassName(declaration: KSClassDeclaration): ClassName? {
+        val mockAnnotation = declaration.annotations
+            .firstOrNull { it.shortName.asString() == MOCK_ANNOTATION_NAME }
+
+        if (mockAnnotation == null) {
+            logger.error("@Mock annotation not found", declaration)
+            return null
+        }
+
+        val widgetArgument = mockAnnotation.arguments
+            .firstOrNull { it.name?.asString() == MOCK_CLIENT_ARGUMENT_NAME }
+
+        if (widgetArgument == null) {
+            logger.error("'widget' argument not found in @Mock annotation", declaration)
+            return null
+        }
+
+        val wrappedType = widgetArgument.value as? KSType
+        if (wrappedType == null) {
+            logger.error("Invalid 'widget' argument type in @Mock annotation", declaration)
+            return null
+        }
+
+        return try {
+            wrappedType.toClassName()
+        } catch (e: Exception) {
+            logger.error("Failed to convert wrapped type to ClassName", declaration)
+            null
+        }
+    }
+
+    private fun generateMockRegistry(mockMappings: Map<ClassName, ClassName>) {
+        if (mockMappings.isEmpty()) {
+            logger.info("No mock mappings found, skipping registry generation")
+            return
+        }
+
+        val registryCodeBlock = createRegistryCodeBlock(mockMappings)
+        val registryObject = createRegistryObject(registryCodeBlock)
+
+        try {
+            FileSpec.builder(PACKAGE_NAME, OBJECT_NAME)
+                .addType(registryObject)
+                .build()
+                .writeTo(codeGenerator = codeGenerator, aggregating = true)
+
+            logger.info("Generated MockRegistry with ${mockMappings.size} mappings")
+        } catch (e: Exception) {
+            logger.error("Failed to write MockRegistry file")
+        }
+    }
+
+    private fun createRegistryCodeBlock(mockMappings: Map<ClassName, ClassName>): CodeBlock {
+        return CodeBlock.builder()
+            .add("mapOf(\n")
+            .indent()
+            .apply {
+                mockMappings.entries.forEachIndexed { index, (mockClass, wrappedClass) ->
+                    add("%T::class to ::%T", mockClass, wrappedClass)
+                    if (index < mockMappings.size - 1) {
+                        add(",\n")
+                    } else {
+                        add("\n")
+                    }
+                }
+            }
+            .unindent()
+            .add(")")
+            .build()
+    }
+
+    private fun createRegistryObject(codeBlock: CodeBlock): TypeSpec {
+        return TypeSpec.objectBuilder(OBJECT_NAME)
+            .addProperty(
+                PropertySpec.builder("registry", REGISTRY_MAP_TYPE)
+                    .initializer(codeBlock)
+                    .build()
+            ).addFunction(
+                FunSpec.builder("createMockClient")
+                    .addModifiers(KModifier.INLINE)
+                    .addTypeVariable(TypeVariableName("reified T"))
+                    .addParameter("mockScope", CoroutineScope::class)
+                    .addParameter("specAtt", SpecAtt::class)
+                    .addParameter("device", MiotDevice::class)
+                    .returns(baseMockClient)
+                    .addCode(
+                        CodeBlock.builder()
+                            .addStatement(
+                                "return registry[T::class]?.invoke(mockScope, specAtt, device) ?: %T(mockScope, specAtt, device)",
+                                defaultMockClient
+                            )
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+    }
+
+    @Suppress("unused")
+    private fun Sequence<KSAnnotation>.extractWidgetType(annotationName: String): ClassName? {
+        return firstOrNull { it.shortName.asString() == annotationName }
+            ?.arguments
+            ?.firstOrNull { it.name?.asString() == MOCK_CLIENT_ARGUMENT_NAME }
+            ?.value
+            ?.let { it as? KSType }
+            ?.toClassName()
+    }
+
+    companion object Companion {
+        private const val PACKAGE_NAME = "miwu.support.generated.mock"
+        private const val OBJECT_NAME = "MockRegistry"
+        private const val MOCK_ANNOTATION_NAME = "Mock"
+        private const val MOCK_CLIENT_ARGUMENT_NAME = "mockClient"
+
+        private val baseMockClient = ClassName("miwu.mock.base", "BaseMockMiotDeviceClient")
+        private val defaultMockClient = ClassName("miwu.mock", "DefaultMockMiotDeviceClient")
+
+        private val REGISTRY_MAP_TYPE = Map::class.asClassName()
+            .parameterizedBy(
+                KClass::class.asTypeName().parameterizedBy(STAR),
+                Function3::class.asTypeName().parameterizedBy(
+                    CoroutineScope::class.asTypeName(),
+                    SpecAtt::class.asTypeName(),
+                    MiotDevice::class.asTypeName(),
+                    baseMockClient
+                )
+            )
+    }
+}

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockProcessorProvider.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockProcessorProvider.kt
@@ -1,0 +1,17 @@
+package miwu.processor.mock
+
+
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment as Environment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider as Provider
+
+
+internal class MockProcessorProvider : Provider {
+    override fun create(environment: Environment) = MockProcessor(
+        options = environment.options,
+        codeGenerator = environment.codeGenerator,
+        logger = environment.logger
+    )
+}
+
+
+

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/spec/SpecProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/spec/SpecProcessor.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.runBlocking
 import miwu.support.urn.Urn
 import miwu.miot.kmp.impl.provider.MiotSpecAttrProviderImpl
 import miwu.miot.provider.MiotSpecAttrProvider
+import miwu.processor.MiwuProcessor
 import java.util.Locale
 import com.google.devtools.ksp.processing.SymbolProcessor as Processor
 
@@ -20,13 +21,11 @@ class SpecProcessor(
     private val options: Map<String, String>,
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger
-) : Processor {
+) : MiwuProcessor() {
     private val provider: MiotSpecAttrProvider = MiotSpecAttrProviderImpl()
-    private var isProcessingOver = false
 
-    override fun process(resolver: Resolver): List<KSAnnotated> {
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
         if (options["miwu.spec.enabled"] != "true") return emptyList()
-        if (isProcessingOver) return emptyList()
         runBlocking {
             SPEC_TYPES.forEach { specType ->
                 try {
@@ -36,7 +35,6 @@ class SpecProcessor(
                 }
             }
         }
-        isProcessingOver = true
         return emptyList()
     }
 

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/widget/WidgetProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/widget/WidgetProcessor.kt
@@ -12,20 +12,17 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import miwu.annotation.Widget
+import miwu.processor.MiwuProcessor
 
 internal class WidgetProcessor(
     private val options: Map<String, String>,
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger
-) : Processor {
+) : MiwuProcessor() {
 
-    private var isProcessingOver = false
-
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (isProcessingOver) return emptyList()
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
         val widgetMappings = collectWidgetMappings(resolver)
         generateRegistries(widgetMappings)
-        isProcessingOver = true
         return emptyList()
     }
 
@@ -38,7 +35,10 @@ internal class WidgetProcessor(
                 try {
                     processWidgetDeclaration(declaration, propertyMappings, actionMappings)
                 } catch (e: Exception) {
-                    logger.error("Failed to process widget: ${declaration.qualifiedName?.asString()}", declaration)
+                    logger.error(
+                        "Failed to process widget: ${declaration.qualifiedName?.asString()}",
+                        declaration
+                    )
                 }
             }
         return WidgetMappings(propertyMappings, actionMappings)
@@ -59,7 +59,15 @@ internal class WidgetProcessor(
         }
         val className = declaration.toClassName()
         processBindings(bindings, className, propertyMappings, actionMappings)
-        processLegacyAnnotations(services, properties, actions, className, propertyMappings, actionMappings, declaration)
+        processLegacyAnnotations(
+            services,
+            properties,
+            actions,
+            className,
+            propertyMappings,
+            actionMappings,
+            declaration
+        )
     }
 
     private fun processBindings(
@@ -133,7 +141,12 @@ internal class WidgetProcessor(
             .indent()
             .apply {
                 classMap.forEach { (serviceItem, className) ->
-                    add("(%S to %S) to %T::class.java,\n", serviceItem.service, serviceItem.item, className)
+                    add(
+                        "(%S to %S) to %T::class.java,\n",
+                        serviceItem.service,
+                        serviceItem.item,
+                        className
+                    )
                 }
             }
             .unindent()
@@ -167,8 +180,10 @@ internal class WidgetProcessor(
         return filter { it.shortName.asString() == annotationName }
             .mapNotNull { annotation ->
                 try {
-                    val service = annotation.getArgumentValue("service") as? String ?: return@mapNotNull null
-                    val item = annotation.getArgumentValue("item") as? String ?: return@mapNotNull null
+                    val service =
+                        annotation.getArgumentValue("service") as? String ?: return@mapNotNull null
+                    val item =
+                        annotation.getArgumentValue("item") as? String ?: return@mapNotNull null
                     val typeName = annotation.annotationType.resolve().arguments
                         .firstOrNull()?.type?.resolve()?.declaration?.qualifiedName?.asString()
                         ?: return@mapNotNull null
@@ -198,11 +213,13 @@ internal class WidgetProcessor(
         val propertyMappings: Map<ServiceItem, ClassName>,
         val actionMappings: Map<ServiceItem, ClassName>
     )
+
     private enum class BindingType {
         PROPERTY, ACTION, UNKNOWN
     }
+
     companion object {
-        private const val PACKAGE_NAME = "miwu.widget.generated.widget"
+        private const val PACKAGE_NAME = "miwu.support.generated.widget"
         private const val PROPERTY_REGISTRY_NAME = "PropertyRegistry"
         private const val ACTION_REGISTRY_NAME = "ActionRegistry"
 

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/wrapper/WrapperProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/wrapper/WrapperProcessor.kt
@@ -13,26 +13,21 @@ import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.ksp.toClassName
 import com.squareup.kotlinpoet.ksp.writeTo
 import miwu.annotation.Wrapper
+import miwu.processor.MiwuProcessor
 
 internal class WrapperProcessor(
     private val options: Map<String, String>,
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger
-) : Processor {
+) : MiwuProcessor() {
 
-    private var isProcessingOver = false
-
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (isProcessingOver) return emptyList()
-
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
         try {
             val wrapperMappings = collectWrapperMappings(resolver)
             generateWrapperRegistry(wrapperMappings)
         } catch (e: Exception) {
             logger.error("Failed to process wrapper annotations")
         }
-
-        isProcessingOver = true
         return emptyList()
     }
 
@@ -166,7 +161,7 @@ internal class WrapperProcessor(
     }
 
     companion object {
-        private const val PACKAGE_NAME = "miwu.widget.generated.wrapper"
+        private const val PACKAGE_NAME = "miwu.support.generated.wrapper"
         private const val OBJECT_NAME = "WrapperRegistry"
         private const val WRAPPER_ANNOTATION_NAME = "Wrapper"
         private const val WIDGET_ARGUMENT_NAME = "widget"

--- a/miwu-support-processor/src/commonMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/miwu-support-processor/src/commonMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -3,4 +3,4 @@ miwu.processor.widget.WidgetProcessorProvider
 miwu.processor.device.DeviceProcessorProvider
 miwu.processor.icon.IconsProcessorProvider
 miwu.processor.wrapper.WrapperProcessorProvider
-
+miwu.processor.mock.MockProcessorProvider

--- a/miwu-support/src/main/java/miwu/mock/DefaultMockMiotDeviceClient.kt
+++ b/miwu-support/src/main/java/miwu/mock/DefaultMockMiotDeviceClient.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.CoroutineScope
 import miwu.miot.model.att.SpecAtt
 import miwu.miot.model.miot.MiotDevice
 
-class NormalMockMiotDeviceClient(
+class DefaultMockMiotDeviceClient(
     mockScope: CoroutineScope,
     specAtt: SpecAtt,
     device: MiotDevice,

--- a/miwu-support/src/main/java/miwu/mock/MockMiotDeviceClient.kt
+++ b/miwu-support/src/main/java/miwu/mock/MockMiotDeviceClient.kt
@@ -3,6 +3,7 @@ package miwu.mock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import miwu.annotation.basic.MockClient
 import miwu.miot.att.get.GetAtt
 import miwu.miot.att.set.SetAtt
 import miwu.miot.att.set.piid
@@ -53,7 +54,7 @@ abstract class MockMiotDeviceClient(
     val mockScope: CoroutineScope,
     val specAtt: SpecAtt,
     device: MiotDevice,
-) : BaseMockMiotDeviceClient(device) {
+) : BaseMockMiotDeviceClient(device), MockClient {
     private val mockStore: MockStore =
         specAtt.services.associate { service ->
             service.properties


### PR DESCRIPTION
- **新增 Mock 相关支持**：
    - 引入 `@Mock` 注解与 `MockClient` 接口，用于配置模拟客户端。
    - 实现 `MockProcessor`，自动生成 `MockRegistry` 以管理模拟客户端的映射与创建。
    - 将 `NormalMockMiotDeviceClient` 重命名为 `DefaultMockMiotDeviceClient`。
- **重构 KSP 处理器架构**：
    - 引入抽象基类 `MiwuProcessor`，统一管理 `isProcessingOver` 状态逻辑，简化子类实现。
    - 更新 `DeviceProcessor`、`WidgetProcessor`、`WrapperProcessor` 等处理器继承自 `MiwuProcessor`。
- **规范包名与路径**：
    - 将生成的代码包名从 `miwu.widget.generated.*` 统一迁移至 `miwu.support.generated.*`。
- **其他改进**：
    - 在 `MockMiotDeviceClient` 中实现 `MockClient` 接口。
    - 注册 `MockProcessorProvider` 到 KSP 服务发现列表。