### PR TITLE
Feat: 引入基于 YAML 配置的 Mock 设备自动生成机制

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 }
 
 val tag = latestGitTag
+val mockDevicesFile = layout.projectDirectory.file("mock-devices.yaml")
 
 android {
     namespace = "com.github.miwu"
@@ -67,6 +68,12 @@ android {
 
 ksp {
     arg("room.schemaLocation", "$projectDir/schemas")
+    arg("miwu.mock.enabled", "true")
+    arg("miwu.mock.filePath", mockDevicesFile.asFile.absolutePath)
+}
+
+tasks.matching { it.name.startsWith("ksp") }.configureEach {
+    inputs.file(mockDevicesFile)
 }
 
 dependencies {
@@ -82,6 +89,7 @@ dependencies {
 
 
     implementation(libs.glide)
+    ksp(project(":miwu-support-processor"))
     ksp(libs.glide.compiler)
 
 

--- a/app/mock-devices.yaml
+++ b/app/mock-devices.yaml
@@ -1,0 +1,10 @@
+enabled: true
+devices:
+  - name: NWT智能除湿机23L
+    did: mock-nwt-derh-n23l
+    model: nwt.derh.n23l
+    specType: urn:miot-spec-v2:device:dehumidifier:0000A02D:nwt-n23l:1:0000D025
+    isOnline: true
+    mac: 00:00:00:00:00:00
+    uid: "114514"
+    roomName:

--- a/app/src/main/java/com/github/miwu/logic/usecase/device/GetSortedDevicesUseCase.kt
+++ b/app/src/main/java/com/github/miwu/logic/usecase/device/GetSortedDevicesUseCase.kt
@@ -1,11 +1,12 @@
 package com.github.miwu.logic.usecase.device
 
+import com.github.miwu.BuildConfig
+import com.github.miwu.mock.GeneratedMockDevices
 import com.github.miwu.logic.repository.CacheRepository
 import com.github.miwu.logic.repository.MiotRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import miwu.miot.model.miot.MiotDevice
-import miwu.support.mock.MockMiotDevice
 
 class GetSortedDevicesUseCase(
     private val miotRepository: MiotRepository,
@@ -13,20 +14,9 @@ class GetSortedDevicesUseCase(
 ) {
     operator fun invoke(): Flow<List<MiotDevice>> {
         return miotRepository.currentHome.map { resultat ->
-            resultat.getOrNull()
-                ?.devices
-                .orEmpty()
-                .toMutableList()
-                .apply {
-                    add(
-                        MockMiotDevice(
-                            name = "NWT智能除湿机23L",
-                            did = "012345689abcdef",
-                            model = "nwt.derh.n23l",
-                            specType = "urn:miot-spec-v2:device:dehumidifier:0000A02D:nwt-n23l:1:0000D025"
-                        )
-                    )
-                }
+            val mockDevices = loadMockDevices()
+
+            (resultat.getOrNull()?.devices.orEmpty() + mockDevices)
                 .sortedWith(
                     compareBy(
                         { !it.isOnline },
@@ -39,9 +29,10 @@ class GetSortedDevicesUseCase(
 
     operator fun invoke(roomName: String): Flow<List<MiotDevice>> {
         return miotRepository.currentHome.map { resultat ->
-            resultat.getOrNull()
-                ?.rooms?.get(roomName)
-                .orEmpty()
+            val mockDevices = loadMockDevices()
+                .filter { GeneratedMockDevices.rooms[it.did] == roomName }
+
+            (resultat.getOrNull()?.rooms?.get(roomName).orEmpty() + mockDevices)
                 .sortedWith(
                     compareBy(
                         { !it.isOnline },
@@ -52,4 +43,14 @@ class GetSortedDevicesUseCase(
         }
     }
 
+    private suspend fun loadMockDevices(): List<MiotDevice> {
+        if (!BuildConfig.DEBUG || !GeneratedMockDevices.enabled) return emptyList()
+
+        val devices = GeneratedMockDevices.devices
+        if (devices.isEmpty()) return emptyList()
+
+        cacheRepository.addIcon(devices.map(MiotDevice::model))
+        cacheRepository.addRoom(GeneratedMockDevices.rooms)
+        return devices
+    }
 }

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockDeviceListProcessor.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockDeviceListProcessor.kt
@@ -1,0 +1,298 @@
+package miwu.processor.mock
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+import miwu.processor.MiwuProcessor
+import java.io.File
+
+internal class MockDeviceListProcessor(
+    private val options: Map<String, String>,
+    private val codeGenerator: CodeGenerator,
+    private val logger: KSPLogger,
+) : MiwuProcessor() {
+
+    override fun onProcess(resolver: Resolver): List<KSAnnotated> {
+        val filePath = options[OPTION_FILE_PATH] ?: return emptyList()
+        val gradleEnabled = options[OPTION_ENABLED] != "false"
+        val config = if (gradleEnabled) {
+            loadConfig(filePath)
+        } else {
+            MockDeviceConfig(enabled = false, devices = emptyList())
+        }
+
+        generate(config.copy(enabled = gradleEnabled && config.enabled))
+        return emptyList()
+    }
+
+    private fun loadConfig(filePath: String): MockDeviceConfig {
+        val file = File(filePath)
+        if (!file.isFile) {
+            logger.error("$filePath not found")
+            return MockDeviceConfig(enabled = false, devices = emptyList())
+        }
+
+        return parseYaml(file.readLines())
+    }
+
+    private fun parseYaml(lines: List<String>): MockDeviceConfig {
+        var enabled = true
+        var inDevices = false
+        var currentDevice: MutableMap<String, String?>? = null
+        val devices = mutableListOf<MutableMap<String, String?>>()
+
+        lines.forEachIndexed { index, rawLine ->
+            val line = rawLine.stripComment().trimEnd()
+            if (line.isBlank()) return@forEachIndexed
+
+            val indent = line.takeWhile(Char::isWhitespace).length
+            val content = line.trim()
+
+            if (indent == 0) {
+                when {
+                    content == "devices:" -> {
+                        inDevices = true
+                        currentDevice = null
+                    }
+
+                    content.startsWith("enabled:") -> {
+                        enabled = content.valueAfterColon()?.toBooleanYaml()
+                            ?: errorAt(index, "enabled must be true or false")
+                    }
+
+                    else -> errorAt(index, "unsupported root key")
+                }
+                return@forEachIndexed
+            }
+
+            if (!inDevices) errorAt(index, "mock device fields must be under devices")
+
+            if (content.startsWith("- ")) {
+                currentDevice = mutableMapOf<String, String?>()
+                    .also(devices::add)
+
+                val firstField = content.removePrefix("- ").trim()
+                if (firstField.isNotEmpty()) {
+                    currentDevice.putField(index, firstField)
+                }
+                return@forEachIndexed
+            }
+
+            val device = currentDevice ?: errorAt(index, "device field must start with '-'")
+            device.putField(index, content)
+        }
+
+        return MockDeviceConfig(
+            enabled = enabled,
+            devices = devices.mapIndexedNotNull { index, device ->
+                device.toMockDevice(index)
+            }
+        )
+    }
+
+    private fun MutableMap<String, String?>.putField(index: Int, content: String) {
+        val key = content.substringBefore(':').trim()
+        if (key == content) errorAt(index, "expected key: value")
+        if (key !in DEVICE_KEYS) errorAt(index, "unsupported device key: $key")
+        this[key] = content.valueAfterColon()
+    }
+
+    private fun Map<String, String?>.toMockDevice(index: Int): MockDevice? {
+        fun required(key: String): String {
+            return this[key]?.takeIf(String::isNotBlank)
+                ?: errorAt(index, "device missing required key: $key")
+        }
+
+        return MockDevice(
+            name = required("name"),
+            did = required("did"),
+            model = required("model"),
+            specType = required("specType"),
+            isOnline = this["isOnline"]?.toBooleanYaml()
+                ?: true,
+            mac = this["mac"]?.takeIf(String::isNotBlank)
+                ?: DEFAULT_MAC,
+            uid = this["uid"]?.takeIf(String::isNotBlank)
+                ?: DEFAULT_UID,
+            roomName = this["roomName"]?.takeIf(String::isNotBlank),
+        )
+    }
+
+    private fun generate(config: MockDeviceConfig) {
+        FileSpec.builder(GENERATED_PACKAGE, OBJECT_NAME)
+            .addType(
+                TypeSpec.objectBuilder(OBJECT_NAME)
+                    .addProperty(
+                        PropertySpec.builder("enabled", Boolean::class, KModifier.CONST)
+                            .initializer("%L", config.enabled)
+                            .build()
+                    )
+                    .addProperty(
+                        PropertySpec.builder(
+                            "devices",
+                            List::class.asClassName().parameterizedBy(MiotDevice)
+                        )
+                            .initializer(createDevicesCode(config.devices))
+                            .build()
+                    )
+                    .addProperty(
+                        PropertySpec.builder(
+                            "rooms",
+                            Map::class.asClassName().parameterizedBy(String::class.asClassName(), String::class.asClassName())
+                        )
+                            .initializer(createRoomsCode(config.devices))
+                            .build()
+                    )
+                    .build()
+            )
+            .build()
+            .writeTo(codeGenerator = codeGenerator, aggregating = false)
+    }
+
+    private fun createDevicesCode(devices: List<MockDevice>): CodeBlock {
+        if (devices.isEmpty()) return CodeBlock.of("emptyList()")
+
+        return CodeBlock.builder()
+            .add("listOf(\n")
+            .indent()
+            .apply {
+                devices.forEach { device ->
+                    add(
+                        "%M(\n",
+                        MockMiotDevice
+                    )
+                    indent()
+                    add("name = %S,\n", device.name)
+                    add("did = %S,\n", device.did)
+                    add("model = %S,\n", device.model)
+                    add("specType = %S,\n", device.specType)
+                    add("isOnline = %L,\n", device.isOnline)
+                    add("mac = %S,\n", device.mac)
+                    add("uid = %S,\n", device.uid)
+                    unindent()
+                    add("),\n")
+                }
+            }
+            .unindent()
+            .add(")")
+            .build()
+    }
+
+    private fun createRoomsCode(devices: List<MockDevice>): CodeBlock {
+        val rooms = devices.mapNotNull { device ->
+            device.roomName?.let { roomName -> device.did to roomName }
+        }
+        if (rooms.isEmpty()) return CodeBlock.of("emptyMap()")
+
+        return CodeBlock.builder()
+            .add("mapOf(\n")
+            .indent()
+            .apply {
+                rooms.forEach { (did, roomName) ->
+                    add("%S to %S,\n", did, roomName)
+                }
+            }
+            .unindent()
+            .add(")")
+            .build()
+    }
+
+    private fun String.valueAfterColon(): String? {
+        return substringAfter(':', missingDelimiterValue = "")
+            .trim()
+            .takeIf(String::isNotEmpty)
+            ?.unquote()
+    }
+
+    private fun String.stripComment(): String {
+        var singleQuoted = false
+        var doubleQuoted = false
+
+        forEachIndexed { index, char ->
+            when (char) {
+                '\'' -> if (!doubleQuoted) singleQuoted = !singleQuoted
+                '"' -> if (!singleQuoted && (index == 0 || this[index - 1] != '\\')) {
+                    doubleQuoted = !doubleQuoted
+                }
+
+                '#' -> if (!singleQuoted && !doubleQuoted) {
+                    return substring(0, index)
+                }
+            }
+        }
+
+        return this
+    }
+
+    private fun String.unquote(): String {
+        return when {
+            length >= 2 && first() == '"' && last() == '"' ->
+                substring(1, lastIndex).replace("\\\"", "\"").replace("\\\\", "\\")
+
+            length >= 2 && first() == '\'' && last() == '\'' ->
+                substring(1, lastIndex).replace("''", "'")
+
+            else -> this
+        }
+    }
+
+    private fun String.toBooleanYaml(): Boolean? {
+        return when (lowercase()) {
+            "true" -> true
+            "false" -> false
+            else -> null
+        }
+    }
+
+    private fun errorAt(index: Int, message: String): Nothing {
+        error("mock-devices.yaml line ${index + 1}: $message")
+    }
+
+    private data class MockDeviceConfig(
+        val enabled: Boolean,
+        val devices: List<MockDevice>,
+    )
+
+    private data class MockDevice(
+        val name: String,
+        val did: String,
+        val model: String,
+        val specType: String,
+        val isOnline: Boolean,
+        val mac: String,
+        val uid: String,
+        val roomName: String?,
+    )
+
+    private companion object {
+        private const val OPTION_ENABLED = "miwu.mock.enabled"
+        private const val OPTION_FILE_PATH = "miwu.mock.filePath"
+        private const val GENERATED_PACKAGE = "com.github.miwu.mock"
+        private const val OBJECT_NAME = "GeneratedMockDevices"
+        private const val DEFAULT_MAC = "00:00:00:00:00:00"
+        private const val DEFAULT_UID = "114514"
+        private val DEVICE_KEYS = setOf(
+            "name",
+            "did",
+            "model",
+            "specType",
+            "isOnline",
+            "mac",
+            "uid",
+            "roomName",
+        )
+        private val MiotDevice = ClassName("miwu.miot.model.miot", "MiotDevice")
+        private val MockMiotDevice = MemberName("miwu.support.mock", "MockMiotDevice")
+    }
+}

--- a/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockDeviceListProcessorProvider.kt
+++ b/miwu-support-processor/src/commonMain/kotlin/miwu/processor/mock/MockDeviceListProcessorProvider.kt
@@ -1,0 +1,12 @@
+package miwu.processor.mock
+
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment as Environment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider as Provider
+
+internal class MockDeviceListProcessorProvider : Provider {
+    override fun create(environment: Environment) = MockDeviceListProcessor(
+        options = environment.options,
+        codeGenerator = environment.codeGenerator,
+        logger = environment.logger
+    )
+}

--- a/miwu-support-processor/src/commonMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/miwu-support-processor/src/commonMain/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -4,3 +4,4 @@ miwu.processor.device.DeviceProcessorProvider
 miwu.processor.icon.IconsProcessorProvider
 miwu.processor.wrapper.WrapperProcessorProvider
 miwu.processor.mock.MockProcessorProvider
+miwu.processor.mock.MockDeviceListProcessorProvider


### PR DESCRIPTION
- **新增 Mock 设备配置**:
    - 添加 `app/mock-devices.yaml`，支持通过配置文件定义 Mock 设备的名称、型号、`specType`、房间映射等信息。
- **新增 `MockDeviceListProcessor`**:
    - 开发 KSP 处理器，用于解析 `mock-devices.yaml` 并自动生成 `GeneratedMockDevices` Kotlin 对象。
    - 支持 YAML 解析逻辑，包括注释处理、引号脱钩及基础类型转换。
    - 自动生成设备列表（`devices`）和房间映射（`rooms`）的代码块。
- **优化 `GetSortedDevicesUseCase`**:
    - 集成生成的 `GeneratedMockDevices`，在 Debug 模式且开启 Mock 时自动加载设备。
    - 改进设备获取与过滤逻辑，支持将 Mock 设备合并至真实设备列表或按房间进行过滤。
    - 自动将 Mock 设备的图标和房间信息同步至 `CacheRepository`。
- **构建配置更新**:
    - 在 `app/build.gradle.kts` 中配置 KSP 参数（`miwu.mock.enabled`, `miwu.mock.filePath`）。
    - 将 `mock-devices.yaml` 设为 KSP 任务的输入文件，确保配置变更时能触发重新编译。
    - 注册 `MockDeviceListProcessorProvider` 到 KSP 服务发现机制。